### PR TITLE
Port to Vintage Story 1.22.3 (.NET 10)

### DIFF
--- a/CakeBuild/CakeBuild.csproj
+++ b/CakeBuild/CakeBuild.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/CakeBuild/Program.cs
+++ b/CakeBuild/Program.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-using System.Runtime.Versioning;
 using Cake.Common;
 using Cake.Common.IO;
 using Cake.Common.Tools.DotNet;
@@ -55,7 +53,7 @@ public class BuildContext : FrostingContext
 	public string ModAssetsVersion { get; }
 	public string ModAssetsName { get; }
 	public bool SkipJsonValidation { get; set; }
-	public string TargetFramework { get; set; }
+	public const string TargetFramework = "net10.0";
 
 
 	public BuildContext(ICakeContext context)
@@ -63,7 +61,6 @@ public class BuildContext : FrostingContext
 	{
 		BuildConfiguration = context.Argument("configuration", "Release");
 		SkipJsonValidation = context.Argument("skipJsonValidation", false);
-		TargetFramework = context.Argument("framework", DetectTargetFramework());
 
 		var modInfoPath = Path.Combine(Program.SolutionDirectory, ProjectName, "modinfo.json");
 		var modInfo = context.DeserializeJsonFromFile<ModInfo>(modInfoPath);
@@ -74,60 +71,6 @@ public class BuildContext : FrostingContext
 		var modAssetsInfo = context.DeserializeJsonFromFile<ModInfo>(modAssetsInfoPath);
 		ModAssetsVersion = modAssetsInfo.Version;
 		ModAssetsName = modAssetsInfo.ModID;
-	}
-	
-	public string AdjustVersionForFilename(string version)
-	{
-		if (TargetFramework == "net7.0")
-		{
-			return version + "-vs120";
-		}
-		return version;
-	}
-	
-	private string DetectTargetFramework()
-	{
-		try
-		{
-			// Get the Vintage Story API path from environment variable
-			var vsPath = Environment.GetEnvironmentVariable("VINTAGE_STORY");
-			if (string.IsNullOrEmpty(vsPath))
-			{
-				Console.WriteLine("VINTAGE_STORY environment variable not set. Defaulting to net8.0");
-				return "net8.0";
-			}
-            
-			// Path to the main API DLL
-			var apiDllPath = Path.Combine(vsPath, "VintagestoryAPI.dll");
-			if (!File.Exists(apiDllPath))
-			{
-				Console.WriteLine($"VintagestoryAPI.dll not found at {apiDllPath}. Defaulting to net8.0");
-				return "net8.0";
-			}
-            
-			// Load the assembly and check its target framework
-			var assembly = Assembly.LoadFile(apiDllPath);
-			var targetFrameworkAttribute = assembly.GetCustomAttribute<TargetFrameworkAttribute>();
-            
-			if (targetFrameworkAttribute != null)
-			{
-				var frameworkName = targetFrameworkAttribute.FrameworkName;
-				Console.WriteLine($"Detected framework: {frameworkName}");
-                
-				if (frameworkName.Contains(".NETCoreApp,Version=v7."))
-					return "net7.0";
-				else if (frameworkName.Contains(".NETCoreApp,Version=v8."))
-					return "net8.0";
-			}
-            
-			// Fallback to checking assembly references for .NET version indicators
-			return "net8.0"; // Default to the latest if can't determine
-		}
-		catch (Exception ex)
-		{
-			Console.WriteLine($"Error detecting framework: {ex.Message}");
-			return "net8.0"; // Default to the latest if detection fails
-		}
 	}
 
 }
@@ -179,7 +122,7 @@ public sealed class BuildTask : FrostingTask<BuildContext>
 			new DotNetPublishSettings
 			{
 				Configuration = context.BuildConfiguration,
-				Framework = context.TargetFramework
+				Framework = BuildContext.TargetFramework
 			});
 	}
 }
@@ -240,7 +183,7 @@ public sealed class PackageModTask : FrostingTask<BuildContext>
 		context.CopyFile($"{projectDir}/compatibility.json", $"{buildDir}/assets/vintagesymphony/config/compatibility.json");
 
 		// package mod
-		context.Zip(buildDir, $"{releasePath}/{context.ModName}_{context.AdjustVersionForFilename(context.ModVersion)}.zip");
+		context.Zip(buildDir, $"{releasePath}/{context.ModName}_{context.ModVersion}.zip");
 	}
 }
 

--- a/VintageSymphony/Situations/Facts/SituationalFactsCollector.cs
+++ b/VintageSymphony/Situations/Facts/SituationalFactsCollector.cs
@@ -291,7 +291,7 @@ public class SituationalFactsCollector
 			entityToPlayerVec.Y = 0; // Ignore height difference for direction check
 			entityToPlayerVec = entityToPlayerVec.Normalize();
 
-			var entityMovementVec = entity.ServerPos.Motion.Clone();
+			var entityMovementVec = entity.Pos.Motion.Clone();
 			entityMovementVec.Y = 0; // Ignore vertical motion
 
 			var movingTowardPlayer = false;
@@ -408,6 +408,6 @@ public class SituationalFactsCollector
 		return isEnemy;
 	}
 
-	static BlockSelection raytraceIntersectionBlock = new();
-	static EntitySelection raytraceIntersectionEntity = new();
+	static BlockSelection? raytraceIntersectionBlock = new();
+	static EntitySelection? raytraceIntersectionEntity = new();
 }

--- a/VintageSymphony/VintageSymphony.csproj
+++ b/VintageSymphony/VintageSymphony.csproj
@@ -11,7 +11,7 @@
         <Authors>VintageSymphony</Authors>
         <Company>VintageSymphony</Company>
         <Product>VintageSymphony</Product>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="cairo-sharp">

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.0",
+    "version": "10.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
## Summary
VS 1.22.3 ships on .NET 10, which requires a single-target build. This is a minimal, targeted port with no other functional changes:

- `global.json` / `VintageSymphony.csproj` / `CakeBuild.csproj`: bump to `net10.0` (dropping the `net7.0`/`net8.0` dual-targeting, since 1.22.3 no longer runs those)
- `CakeBuild/Program.cs`: removes the now-dead runtime framework auto-detection (`DetectTargetFramework` / `AdjustVersionForFilename`) that existed to pick between net7/net8 - only one target remains, so it's unneeded
- `SituationalFactsCollector.cs`: replaces the one obsolete API hit, `Entity.ServerPos` → `Entity.Pos`

## Test plan
- [x] `dotnet build -c Debug` succeeds against a real Vintage Story 1.22.3 install with 0 errors
- [x] Full `CakeBuild` publish pipeline runs against the updated `VintageSymphony.csproj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)